### PR TITLE
feat: using The FreeDesktop.org Trash specification on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ keymap("x", "<leader>x", genghis.moveSelectionToNewFile)
 > - If the new file name includes a `/`, the new file is placed in the respective subdirectory, creating any non-existing folders. Except for `.moveAndRenameFile`, all operations take only place in the current working directory, so `.moveAndRenameFile` is the only command that can move to a parent directory.
 > - All commands support [autocompletion of existing directories](#autocompletion-of-directories).
 
-- `.trashFile{trashLocation = "your/path/"}`: Move the current file the trash location. Defaults to location is `$HOME/.Trash/`. ⚠️ Any existing file in the trash location with the same name is overwritten, making that file irretrievable.
+- `.trashFile{trashLocation = "your/path/"}`: Move the current file the trash location. Default locations are: `$HOME/.Trash/` on MacOS and `$XDG_DATA_HOME/Trash` on Linux. ⚠️ Any existing file in the trash location with the same name is overwritten, making that file irretrievable.
 - `.copyFilename`: Copy the file name. When `clipboard="unnamed[plus]"` has been set, copies to the `+` register, otherwise to `"`.
 - `.copyFilepath`: Copy the absolute file path. When `clipboard="unnamed[plus]"` has been set, copies to the `+` register, otherwise to `"`.
 - `.chmodx`: Makes current file executable. Equivalent to `chmod +x`.

--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -159,7 +159,19 @@ end
 ---@param opts? table
 function M.trashFile(opts)
 	cmd.update { bang = true }
-	local trash = os.getenv("HOME") .. "/.Trash/"
+	local trash
+
+	if vim.fn.has('linux') == 1 then
+		local xdg_data = os.getenv("XDG_DATA_HOME")
+		if xdg_data then
+			trash = xdg_data .. "/Trash"
+		else
+			trash = os.getenv("HOME") .. "/.local/share/Trash"
+		end
+	else
+		trash = os.getenv("HOME") .. "/.Trash"
+	end
+
 	if opts and opts.trashLocation then
 		trash = opts.trashLocation
 		if not (trash:find("/$")) then trash = trash .. "/" end


### PR DESCRIPTION
Hi,
I know you can change the directory with `trashLocation = "your/path"`, but I think it would be a usability improvement if, on Linux, we can use the [The FreeDesktop.org Trash specification](https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html) witch is the standard on every desktop environment.