### PR TITLE
feat: add global variable to disable Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ keymap("x", "<leader>x", genghis.moveSelectionToNewFile)
 - `.copyFilepath` or `:CopyFilepath`: Copy the absolute file path. When `clipboard="unnamed[plus]"` has been set, copies to the `+` register, otherwise to `"`.
 - `.chmodx` or `:Chmodx`: Makes current file executable. Equivalent to `chmod +x`.
 
+### How to disable command-line commands
+Put this in your configuration file:
+```lua
+-- lua
+vim.g.genghis_disable_commands = true
+```
+or
+```vim
+-- viml
+let g:genghis_disable_commands = v:true
+```
+
 ## Autocompletion of directories
 You can get autocompletion for directories by using `dressing.nvim`, `nvim-cmp`, and vim's omnifunc:
 

--- a/plugin/genghis.lua
+++ b/plugin/genghis.lua
@@ -1,12 +1,18 @@
-local command = vim.api.nvim_create_user_command
-local genghis = require("genghis")
+if vim.fn.exists("g:genghis_disable_commands") == 0 then
+    vim.g.genghis_disable_commands = false
+end
 
-command("NewFromSelection", function() genghis.moveSelectionToNewFile() end, {})
-command("Duplicate", function() genghis.duplicateFile() end, {})
-command("Rename", function() genghis.renameFile() end, {})
-command("Trash", function() genghis.trashFile() end, {})
-command("Move", function() genghis.moveAndRenameFile() end, {})
-command("CopyFilename", function() genghis.copyFilename() end, {})
-command("CopyFilepath", function() genghis.copyFilepath() end, {})
-command("Chmodx", function() genghis.chmodx() end, {})
-command("New", function() genghis.createNewFile() end, {})
+if not vim.g.genghis_disable_commands then
+    local command = vim.api.nvim_create_user_command
+    local genghis = require("genghis")
+
+    command("NewFromSelection", function() genghis.moveSelectionToNewFile() end, {})
+    command("Duplicate", function() genghis.duplicateFile() end, {})
+    command("Rename", function() genghis.renameFile() end, {})
+    command("Trash", function() genghis.trashFile() end, {})
+    command("Move", function() genghis.moveAndRenameFile() end, {})
+    command("CopyFilename", function() genghis.copyFilename() end, {})
+    command("CopyFilepath", function() genghis.copyFilepath() end, {})
+    command("Chmodx", function() genghis.chmodx() end, {})
+    command("New", function() genghis.createNewFile() end, {})
+end


### PR DESCRIPTION
Hi,
I thought it is a good idea to add a way to disable the `:Commands`, if the user wants to implements is own ones or just don't want them. 