### PR TITLE
fix: trash command not working

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -164,12 +164,12 @@ function M.trashFile(opts)
 	if vim.fn.has('linux') == 1 then
 		local xdg_data = os.getenv("XDG_DATA_HOME")
 		if xdg_data then
-			trash = xdg_data .. "/Trash"
+			trash = xdg_data .. "/Trash/"
 		else
-			trash = os.getenv("HOME") .. "/.local/share/Trash"
+			trash = os.getenv("HOME") .. "/.local/share/Trash/"
 		end
 	else
-		trash = os.getenv("HOME") .. "/.Trash"
+		trash = os.getenv("HOME") .. "/.Trash/"
 	end
 
 	if opts and opts.trashLocation then


### PR DESCRIPTION
Hi,
in #7 I've accidentally introduced a bug, where when using the trash command it doesn't recognise the trash directory as a directory.