### PR TITLE
feat: update buffer after chmodx

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -165,6 +165,7 @@ function M.chmodx()
 	perm = perm:gsub("r(.)%-", "r%1x") -- add x to every group that has r
 	fn.setfperm(filename, perm)
 	vim.notify("Execution Permission granted.")
+    cmd.edit()
 end
 
 ---Trash the current File.


### PR DESCRIPTION
Hi,
There was this feature in vim eununch that I really liked, that when you where editing a script it will auto chmodx the file and reload it. This made vim activate the syntax highliting on scripts that don't had an extention. This simply adds that when you chmod a file that file is reloaded.


https://user-images.githubusercontent.com/96259932/225054239-7efd5d96-bc8a-4e11-8701-82f9b66ef3e7.mov

