### PR TITLE
Add range option to NewFromSelection command

### DIFF
--- a/plugin/genghis.lua
+++ b/plugin/genghis.lua
@@ -6,7 +6,7 @@ if not vim.g.genghis_disable_commands then
     local command = vim.api.nvim_create_user_command
     local genghis = require("genghis")
 
-    command("NewFromSelection", function() genghis.moveSelectionToNewFile() end, {})
+    command("NewFromSelection", function() genghis.moveSelectionToNewFile() end, { range = true })
     command("Duplicate", function() genghis.duplicateFile() end, {})
     command("Rename", function() genghis.renameFile() end, {})
     command("Trash", function() genghis.trashFile() end, {})


### PR DESCRIPTION
Hey there! Thanks for the plugin, it is amazing! 

I was trying to use the `:NewFromSelection` command and was getting an error saying that range was not allowed.

It was a missing option on the command definition, so I forked and fixed it.