### PR TITLE
fix: make copy filename command oneline

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -161,7 +161,7 @@ local function copyOp(operation)
 	if operation == "filename" then toCopy = expand("%:t") end
 
 	fn.setreg(reg, toCopy)
-	vim.notify("COPIED\n" .. toCopy)
+	vim.notify("genghis: successfully copied \"" .. toCopy .. "\"")
 end
 
 ---Copy absolute path of current file


### PR DESCRIPTION
This is a if for a small inconvenience I had when using the commands to copy filename and file path. Since there was a new line in the `vim.notify` string, when I was using the commands the editor block and ask me to press enter which is very annoying. This change notify string to something a little more sensible (in my opinion).

#### Old behaviour

<img width="563" alt="Screenshot 2023-06-10 at 18 11 14" src="https://github.com/chrisgrieser/nvim-genghis/assets/96259932/1d970b83-6b47-44de-a8aa-fde402e5f08c">

#### New Behaviour

<img width="776" alt="Screenshot 2023-06-10 at 18 11 33" src="https://github.com/chrisgrieser/nvim-genghis/assets/96259932/2a601961-96aa-4012-bd7d-ee965c28c9a0">