### PR TITLE
Make :Trash mpre robust

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -210,9 +210,16 @@ function M.trashFile(opts)
 		if not (trash:find("/$")) then trash = trash .. "/" end -- append "/"
 	end
 
+	fn.mkdir(trash, "p")
+
 	local currentFile = expand("%:p")
 	local filename = expand("%:t")
-	local success, errormsg = os.rename(currentFile, trash .. filename)
+
+	-- os.rename fails if trash is on different filesystem
+	local success, errormsg = pcall(cmd.write, trash .. filename)
+	if success then
+		success, errormsg = os.remove(currentFile)
+	end
 
 	if success then
 		bwipeout()

--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -192,7 +192,7 @@ function M.trashFile(opts)
 	-- Default trash locations
 	if fn.has("linux") == 1 then
 		local xdg_data = os.getenv("XDG_DATA_HOME")
-		trash = xdg_data and xdg_data .. "/trash/" or home .. "/.local/share/Trash/"
+		trash = xdg_data and xdg_data .. "/Trash/" or home .. "/.local/share/Trash/"
 	elseif fn.has("macunix") == 1 then
 		-- INFO macOS moves files to the icloud trash, if they are deleted from
 		-- icloud folder, otherwise they go the user trash folder


### PR DESCRIPTION
I tried this plugin today and had two errors when deleting a file with `:Trash`

- a "No such file or directory" error occurs, when the trash dir doesn't exist
- an "Invalid cross device link" error occurs, when the trash dir is on a different filesystem

This PR fixes the first one by creating the trash dir, if it doesn't exist. The second one is inherent to os.rename, so I replaced it by first writing the file to the new location and then deleting it (only if the write was successful). This may also help with #12, if that issue is also caused by `os.rename`'s limitations.