### PR TITLE
Fix directory behaviors

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -96,7 +96,7 @@ local function fileOp(op)
 		-- DETERMINE PATH AND EXTENSION
 		local hasPath = newName:find("/")
 		if hasPath then
-			local newFolder = newName:gsub("/.-$", "")
+ 			local newFolder = vim.fs.dirname(newName)
 			fn.mkdir(newFolder, "p") -- create folders if necessary
 		end
 

--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -33,7 +33,7 @@ end
 ---Performing common file operation tasks
 ---@param op string rename|duplicate|new|newFromSel
 local function fileOp(op)
-	local dir = expand("%:p:h")
+	local dir = fn.getcwd()
 	local oldName = expand("%:t")
 	local oldFilePath = expand("%:p")
 	local oldNameNoExt = oldName:gsub("%.%w+$", "")


### PR DESCRIPTION
fixes #29 and also making new files with multiple parent directories (i.e. "a/b/c/e/f.txt" works now)

I chose to do everything relative to `getcwd()` instead of relative to the current file's path.

I also explained the bug with the multiple directories in the commit message.