### PR TITLE
fix: ensure input prompt is cleared

### DIFF
--- a/lua/genghis.lua
+++ b/lua/genghis.lua
@@ -62,7 +62,7 @@ local function fileOp(op)
 	-- selene: allow(high_cyclomatic_complexity)
 	-- INFO completion = "dir" allows for completion via cmp-omni
 	vim.ui.input({ prompt = promptStr, default = prefill, completion = "dir" }, function(newName)
-		cmd("echomsg ''") -- Clear message area from ui.input prompt
+		cmd.redraw() -- Clear message area from ui.input prompt
 
 		-- VALIDATION OF FILENAME
 		if not newName then return end -- input has been cancelled


### PR DESCRIPTION
Fixes: #25

I tried `cmd("echomsg ' '")` and that did push the "result" message onto a new line, but resulted in "Press ENTER or type command to continue" since there were two lines of messages.

Searching around I found https://github.com/nvim-telescope/telescope-file-browser.nvim/blob/ad7b637c72549713b9aaed7c4f9c79c62bcbdff0/lua/telescope/_extensions/file_browser/actions.lua#L122 so tried that technique here and it's working consistently in my testing.