### PR TITLE
fix: trash in *Linux* using a trash command, fixes #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ keymap("n", "<leader>rf", genghis.renameFile)
 keymap("n", "<leader>mf", genghis.moveAndRenameFile)
 keymap("n", "<leader>nf", genghis.createNewFile)
 keymap("n", "<leader>yf", genghis.duplicateFile)
-keymap("n", "<leader>df", function() genghis.trashFile { trashLocation = "your/path" } end) -- default: "$HOME/.Trash".
+keymap("n", "<leader>df", genghis.trashFile)
 keymap("x", "<leader>x", genghis.moveSelectionToNewFile)
 ```
 
@@ -73,6 +73,14 @@ Line Mode command; the selection is moved linewise.)
 - `.moveAndRenameFile` or `:Move`: Move and Rename the current file. Keeps the
 old name if the new path ends with `/`. Works like the UNIX `mv` command. Best
 used with [autocompletion of directories](#autocompletion-of-directories).
+- `.trashFile`: Trash the current file.
+	- Use `trashCmd` to specify an external trash command. It defaults to
+`gio trash` on *Linux*, `trash` on *Mac* and *Windows*.
+	- Otherwise specify `trashLocation` to move the file to that directory. It
+defaults to `$HOME/.Trash`. This does NOT trash the file the usual way. The
+trashed file is NOT restorable to its original path.
+	- For backwards compatibility, the default behavior on *Mac* moves files to
+`$HOME/.Trash`.
 
 The following applies to all commands above:
 - If no extension has been provided, uses the extension of the original file.

--- a/doc/genghis.txt
+++ b/doc/genghis.txt
@@ -1,4 +1,4 @@
-*genghis.txt*           For NVIM v0.8.0          Last change: 2023 December 30
+*genghis.txt*           For NVIM v0.8.0          Last change: 2023 December 31
 
 ==============================================================================
 Table of Contents                                  *genghis-table-of-contents*
@@ -69,7 +69,7 @@ create keybindings for the commands you want to use:
     keymap("n", "<leader>mf", genghis.moveAndRenameFile)
     keymap("n", "<leader>nf", genghis.createNewFile)
     keymap("n", "<leader>yf", genghis.duplicateFile)
-    keymap("n", "<leader>df", function() genghis.trashFile { trashLocation = "your/path" } end) -- default: "$HOME/.Trash".
+    keymap("n", "<leader>df", genghis.trashFile)
     keymap("x", "<leader>x", genghis.moveSelectionToNewFile)
 <
 
@@ -88,6 +88,14 @@ FILE OPERATION COMMAND ~
 - `.moveAndRenameFile` or `:Move`Move and Rename the current file. Keeps the
     old name if the new path ends with `/`. Works like the UNIX `mv` command. Best
     used with |genghis-autocompletion-of-directories|.
+- `.trashFile`Trash the current file.
+    - Use `trashCmd` to specify an external trash command. It defaults to
+        `gio trash` on _Linux_, `trash` on _Mac_ and _Windows_.
+    - Otherwise specify `trashLocation` to move the file to that directory. It
+        defaults to `$HOME/.Trash`. This does NOT trash the file the usual way. The
+        trashed file is NOT restorable to its original path.
+    - For backwards compatibility, the default behavior on _Mac_ moves files to
+        `$HOME/.Trash`.
 
 The following applies to all commands above: - If no extension has been
 provided, uses the extension of the original file. - If the new file name


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  readme.
- [x] Used conventional commits keywords.
