### PR TITLE
feat: try to rename first to preserve metadata

### DIFF
--- a/doc/genghis.txt
+++ b/doc/genghis.txt
@@ -1,4 +1,4 @@
-*genghis.txt*           For NVIM v0.8.0          Last change: 2023 December 30
+*genghis.txt*           For NVIM v0.8.0          Last change: 2023 December 31
 
 ==============================================================================
 Table of Contents                                  *genghis-table-of-contents*

--- a/lua/genghis/file-movement.lua
+++ b/lua/genghis/file-movement.lua
@@ -40,10 +40,14 @@ function M.lspSupportsRenaming()
 	return false
 end
 
----use instead of fs_rename to support moving across partitions
 ---@param oldFilePath string
 ---@param newFilePath string
 function M.moveFile(oldFilePath, newFilePath)
+	local renamed, _renamedError = vim.loop.fs_rename(oldFilePath, newFilePath)
+	if renamed then
+		return true
+	end
+	---try `fs_copyfile` to support moving across partitions
 	local copied, copiedError = vim.loop.fs_copyfile(oldFilePath, newFilePath)
 	if copied then
 		local deleted, deletedError = vim.loop.fs_unlink(oldFilePath)


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  readme.
- [x] Used conventional commits keywords.

The current code uses `vim.loop.fs_copyfile()` instead of `vim.loop.fs_rename()`. This has some issues:

- Files can lose metadata, such as file modification dates.
- Moving large binary files will incur a cost.

This code just tries `vim.loop.fs_rename()` first, and falls back to `vim.loop.fs_copyfile()` if it doesn't work.