### PR TITLE
fix: OS detection when using vim.fn.has

### DIFF
--- a/lua/genghis/init.lua
+++ b/lua/genghis/init.lua
@@ -172,9 +172,9 @@ function M.trashFile(opts)
 	cmd("silent! update")
 
 	local system
-	if fn.has("macos") == 1 then system = "macos" end
+	if fn.has("mac") == 1 then system = "macos" end
 	if fn.has("linux") == 1 then system = "linux" end
-	if fn.has("windows") == 1 then system = "windows" end
+	if fn.has("win32") == 1 then system = "windows" end
 	local trashCmd = opts.trashCmd or defaultTrashCmds[system]
 	
 	-- Use a trash command


### PR DESCRIPTION
```
NVIM v0.9.4
Build type: Release
LuaJIT 2.1.1700008891
```

I had an issue on my Linux env that was returning 1 for `fn.has("windows")` and tried to run `trash` instead of `gio trash`. Looking at the `has()` docs it says that Windows detection should be done using `win32`:
![image](https://github.com/chrisgrieser/nvim-genghis/assets/213193/f8f2b740-a0f9-4e8a-ae86-6e114b01fab3)

## Checklist
- [x] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  readme.
- [x] Used conventional commits keywords.
