### PR TITLE
Fix moveToFolderInCwd when cwd in hidden folder

### DIFF
--- a/lua/genghis/init.lua
+++ b/lua/genghis/init.lua
@@ -135,11 +135,12 @@ function M.moveToFolderInCwd()
 	-- determine destinations in cwd
 	local foldersInCwd = vim.fs.find(function(name, path)
 		local fullPath = path .. osPathSep .. name .. osPathSep
-		local ignoreDirs = fullPath:find("/%.git/")
-			or fullPath:find("%.app/") -- macos pseudo-folders
-			or fullPath:find("/node_modules/")
-			or fullPath:find("/%.venv/")
-			or fullPath:find("/%.") -- hidden folders
+		local relative_path = osPathSep .. vim.fn.fnamemodify(fullPath, ":~:.")
+		local ignoreDirs = relative_path:find("/%.git/")
+			or relative_path:find("%.app/") -- macos pseudo-folders
+			or relative_path:find("/node_modules/")
+			or relative_path:find("/%.venv/")
+			or relative_path:find("/%.") -- hidden folders
 			or fullPath == parentOfCurFile
 		return not ignoreDirs
 	end, { type = "directory", limit = math.huge })


### PR DESCRIPTION
When trying to move a folder in cwd the current implementation uses the full file path. As a consequence if you're cwd is a hidden folder or a descendant of a hidden folder then no options would display.

Proposed solution now is only search for the ignored options in the path relative to the cwd. That way the currently ignored options are scoped by the cwd.

fixes chrisgrieser/nvim-genghis#46

## Checklist
- [x] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  readme.
- [ ] Used conventional commits keywords.
