### PR TITLE
feat: add Linux support for `showInSystemExplorer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Or you can use the ex command `:Genghis` with the respective subcommand:
 - `trashFile`: Move the current file to the trash. (Defaults to `gio trash` on
   *Linux*, and `trash` on *macOS* or *Windows*.)
 - `showInSystemExplorer`: Reveals the current file in the system explorer, such
-  as macOS Finder. (Currently only on macOS, PRs welcome.)
+  as macOS Finder. (Currently only on macOS and Linux, PRs welcome.)
 
 The following applies to all commands above:
 1. If no extension has been provided, uses the extension of the original file.

--- a/lua/genghis/operations/file.lua
+++ b/lua/genghis/operations/file.lua
@@ -258,14 +258,42 @@ function M.trashFile()
 	end
 end
 
+-- Return the first available file manager on Linux, with a "reveal" flag, or nil.
+---@return { exec: string, flag: string }?
+local function getLinuxFileManager()
+	local fileManagers = {
+		{ exec = "dolphin", flag = "--select" }, -- KDE
+		{ exec = "nautilus", flag = "--select" }, -- GNOME
+		{ exec = "nemo", flag = "--" }, -- Cinnamon
+	}
+
+	for _, item in ipairs(fileManagers) do
+		if vim.fn.executable(item.exec) == 1 then return item end
+	end
+
+	return nil
+end
+
 function M.showInSystemExplorer()
 	local notify = require("genghis.support.notify")
-	if jit.os ~= "OSX" then
-		notify("Currently only available on macOS.", "warn")
+	local filepath = vim.api.nvim_buf_get_name(0)
+	local cmd
+
+	if jit.os == "OSX" then
+		cmd = { "open", "-R", filepath }
+	elseif jit.os == "Linux" then
+		local fileManager = getLinuxFileManager()
+		if fileManager then
+			cmd = { fileManager.exec, fileManager.flag, filepath }
+		else -- Fallback: open parent directory, without revealing current file.
+			cmd = { "xdg-open", vim.fs.dirname(filepath) }
+		end
+	else
+		notify("Currently only available on macOS and Linux.", "warn")
 		return
 	end
 
-	local out = vim.system({ "open", "-R", vim.api.nvim_buf_get_name(0) }):wait()
+	local out = vim.system(cmd):wait()
 	if out.code ~= 0 then
 		local icon = require("genghis.config").config.icons.file
 		notify("Failed: " .. out.stderr, "error", { icon = icon })


### PR DESCRIPTION
## Problem statement

`showInSystemExplorer` is currently only supported on macOS.

## Proposed solution

Add support for popular Linux file managers, and a fallback.
Note that I have only been able to test this for `nemo` and the fallback, not for every file manager specified. I have consulted the online man pages of the other file managers though.

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` has been updated for any new or modified functionality
  (the `.txt` file is auto-generated and does not need to be modified).